### PR TITLE
Add Dakera: production-ready self-hosted memory server for RAG pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ their retrieval strategy based on intermediate results.
     infrastructure overhead.
 - [RAGFlow](https://github.com/infiniflow/ragflow) — see [Frameworks & Orchestration](#frameworks--orchestration) for the full entry.
   - Extends the core RAGFlow engine with agentic capabilities: dynamic document re-ranking, query decomposition, and adaptive retrieval strategies based on query complexity.
+- [Dakera](https://github.com/dakera-ai/dakera-mcp)
+  - Production-ready self-hosted agent memory server for RAG pipelines. HNSW vector indexing, RocksDB persistence, decay-weighted recall, and MCP-native interface.
 
 **When to Use Agentic RAG:**
 


### PR DESCRIPTION
## Summary

This PR adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Agentic RAG → Frameworks & Tools** section.

Dakera is a production-ready self-hosted agent memory server purpose-built for RAG pipelines that need persistent, structured memory without third-party cloud dependencies.

- **HNSW vector indexing** — sub-millisecond approximate nearest-neighbor retrieval at scale
- **RocksDB persistence** — durable on-disk storage with predictable write performance under production load
- **Decay-weighted recall** — prevents stale memories from polluting retrieval; surfaces what is contextually relevant now
- **MCP-native interface** — integrates with the tool layer of any MCP-compatible RAG orchestrator
- Written in Rust: low memory footprint, predictable latency, suitable for production self-hosting