### PR TITLE
Add rag-architect production RAG templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,10 @@ own environment.
   - A comprehensive notebook series covering advanced RAG techniques end to end —
     from adaptive retrieval and hybrid search to corrective RAG, self-RAG, and
     agentic pipelines — with annotated, runnable code for each pattern.
+- [greynewell/rag-architect](https://github.com/greynewell/rag-architect)
+  - Hermes Agent profile and template pack for production RAG architecture:
+    ADRs, Pinecone namespace reviews, evaluation plans, observability specs, and
+    implementation-ready GitHub issue templates.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [greynewell/rag-architect](https://github.com/greynewell/rag-architect) to Tutorials & Hands-on Code.

## Why it fits

rag-architect is open-source and production-focused. It provides a Hermes Agent profile plus reusable templates for ADRs, Pinecone namespace reviews, evaluation plans, observability specs, and implementation-ready GitHub issues. It contains no numeric benchmark claims, so the Evidence Tier policy does not apply.