### PR TITLE
Add Superhighway to Data Ingestion & Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,12 @@ Choose the right framework for your use case with this production-focused compar
 - [OmniParse](https://github.com/adithya-s-k/omniparse)
   - Universal parser for ingesting any data type (documents, multimedia, web)
     into RAG-ready formats.
+- [Superhighway](https://superhighway.walls.sh)
+  - Web search API for AI pipelines, exposing search, news, images, scrape, and
+    research endpoints. Pulls fresh, LLM-ready content from the live web to
+    augment a static corpus or ground retrieval in real-time results
+    ([RAG guide](https://superhighway.walls.sh/guides/web-search-rag)). Auth with
+    a free API key or x402 USDC pay-per-call.
 - [Unstructured](https://github.com/Unstructured-IO/unstructured)
   - Open-source pipelines for preprocessing complex, unstructured data.
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh) to the **Data Ingestion & Parsing** section, alongside the existing API-based ingestion tools (Firecrawl, LlamaParse).

Superhighway is a web search API for AI pipelines (search, news, images, scrape, and research endpoints). In a RAG context it serves as a **live-web data source**: pulling fresh, LLM-ready content to augment a static corpus or ground retrieval in real-time results — complementary to the crawl/parse tools already listed.

- Site: https://superhighway.walls.sh
- RAG guide: https://superhighway.walls.sh/guides/web-search-rag

Auth is a free API key (1k requests/month) or x402 USDC pay-per-call. Entry is placed alphabetically and follows the existing two-line title + indented description format. Thanks for maintaining this list!