### PR TITLE
Add Superhighway web search API to Retrieval section

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,13 @@ zero-shot retrieval performance.
     easy to use. ColBERT offers fine-grained token-level matching, providing
     superior retrieval quality compared to standard single-vector dense
     retrieval.
+- [Superhighway Web Search API](https://superhighway.walls.sh)
+  - Web search API for AI agents: search, news, images, scrape, and research
+    endpoints. The guide
+    [Hybrid RAG Router — routing between web search and vector store](https://superhighway.walls.sh/guides/web-search-hybrid-rag-router)
+    covers a keyword classifier, an LLM-based router, and a LangChain LCEL
+    pipeline that queries both a vector store and live web search and merges
+    the context. Pay-per-call with USDC via x402 or free API key.
 
 **GraphRAG:**
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh) to the Retrieval & Reranking section (Hybrid Search subsection).

Superhighway is a web search API (search, news, images, scrape, research) that can replace or augment a vector store in RAG pipelines. The linked guide covers hybrid routing between web search and a vector store — including a keyword classifier, an LLM-based router, and a LangChain LCEL pipeline that queries both sources and merges context.

This complements the existing Data Ingestion entry (PR #55) which covered using Superhighway as a web-only RAG source. The Retrieval entry specifically targets the hybrid retrieval pattern where vector search and live web search are used together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)