### PR TITLE
Add hitgate (label-free retrieval-ranking regression gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,12 @@ Groundedness, and Answer Relevance.
   - The "Pytest for LLMs". It offers a unit-testing framework for RAG,
     integrating seamlessly into CI/CD pipelines to catch regressions in retrieval
     quality or hallucination rates before deployment.
+- [hitgate](https://github.com/LucasSantana-Dev/evidence-first-rag)
+  - A **label-free retrieval-ranking regression gate**: scores Hit@K / MRR for *any*
+    retriever over your own corpus, freezes a baseline, and fails CI on a >5pp drop — no
+    labeled data, no LLM judge. Complements LLM-as-judge tools (Ragas/DeepEval) by catching
+    *retrieval* drift directly in CI. Reproducible across [70 real repos](https://github.com/LucasSantana-Dev/evidence-first-rag/blob/main/docs/portfolio-benchmark.md)
+    (median Hit@1 0.81, zero tuning).
 - [KB Arena](https://github.com/xmpuspus/kb-arena)
   - Benchmarks 9 retrieval architectures (naive vector, contextual vector, QnA
     pairs, knowledge graph, hybrid RRF, RAPTOR, PageIndex, BM25, rerank) on


### PR DESCRIPTION
### What

Adds **[hitgate](https://github.com/LucasSantana-Dev/evidence-first-rag)** to **Evaluation & Benchmarking** (inserted alphabetically before KB Arena).

### Why it fits the gap

The current Evaluation entries are LLM-as-judge (Ragas, DeepEval, TruLens — Faithfulness / Answer Relevance / RAG Triad). hitgate covers the **complementary** axis: a **label-free retrieval-*ranking* regression gate** — it scores Hit@K / MRR for *any* retriever (`module:callable`) over your own corpus, freezes a baseline, and **fails CI on a >5pp drop**, with **no labeled data and no LLM judge**. It catches *retrieval* drift (a wrong-chunk-at-rank-1 regression) directly, before it ever reaches the generation step the LLM-judge tools measure.

### Meets the quality bar

- **Production focus:** a CI regression gate for retrieval quality (reliability) — pure-stdlib core, `pip`-installable, retriever-agnostic.
- **Activity:** actively maintained (commits this week).
- **Documentation:** README, [methodology](https://github.com/LucasSantana-Dev/evidence-first-rag/blob/main/docs/METHODOLOGY.md), ADRs.
- **Evidence (not marketing):** reproducible across **[70 real repos](https://github.com/LucasSantana-Dev/evidence-first-rag/blob/main/docs/portfolio-benchmark.md)** (median Hit@1 0.81, zero tuning) + a 7-corpus hand-curated benchmark. Misses are published, not hidden.

Open-source (MIT). Searched first — no existing entry or open PR for it.