### PR TITLE
Add Vestige to Agent Memory & Stateful Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,12 @@ distinct from the RAG knowledge base itself.
     facts from every conversation turn. Provides a unified API across
     graph-based, vector, and key-value backends; selected as the memory
     provider in the AWS Agent SDK.
+- [Vestige](https://github.com/samvallad33/vestige)
+  <!-- verified: 2026-06-26 -->
+  - Local-first memory MCP server for coding agents, written in Rust with a
+    SQLite store. Uses FSRS-6 retention scheduling, prediction-error gating on
+    writes, spreading activation, and hybrid retrieval, and exposes provenance
+    and correction tools over MCP for Claude Code, Cursor, VS Code, and Codex.
 - [Zep / Graphiti](https://github.com/getzep/graphiti)
   - Zep builds a temporal knowledge graph (Graphiti) where every stored fact
     carries a validity window. Conflicting facts are not stacked — the older


### PR DESCRIPTION
Adds Vestige to the Frameworks & Tools list under Agent Memory & Stateful Context, placed alphabetically between Mem0 and Zep / Graphiti.

Vestige is a local-first memory MCP server for coding agents, written in Rust over a local SQLite store. It fits this section's scope of long-term, cross-session agent memory: it uses FSRS-6 retention scheduling, prediction-error gating on writes, spreading activation, and hybrid retrieval, and exposes provenance and correction tools over MCP for Claude Code, Cursor, VS Code, and Codex. Repo: https://github.com/samvallad33/vestige

Followed CONTRIBUTING.md: fork-and-branch from main, alphabetical order within the category, the two-line link format used throughout the repo, no emoji or bold inline labels in the bullet, and a per-entry Last Verified marker. The entry makes no numeric claim, so the Evidence Tier does not apply. markdownlint-cli2 runs clean (0 errors) against the repo config.