### PR TITLE
Add Semark to Data Ingestion & Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ Choose the right framework for your use case with this production-focused compar
     data across 100+ languages. Its PP-StructureV3 pipeline recovers tables,
     formulas, and reading order, providing a self-hostable parsing layer for
     document-heavy RAG ingestion.
+- [Semark](https://github.com/KingsleyOWO/Semark)
+  <!-- verified: 2026-07-24 -->
+  - An Apache-2.0 document-processing pipeline that combines MinerU evidence
+    with optional local VLM/LLM review to turn forms, flowcharts, tables, and
+    screenshot-heavy manuals into semantic Markdown, structured chunks, source
+    maps, and split documents for RAG ingestion.
 - [Unstructured](https://github.com/Unstructured-IO/unstructured)
   - Open-source pipelines for preprocessing complex, unstructured data.
 


### PR DESCRIPTION
## Description

Adds Semark to Data Ingestion & Parsing. Semark is an Apache-2.0, self-hostable document-processing pipeline for RAG that combines MinerU parsing evidence with optional local VLM/LLM review. It targets forms, flowcharts, tables, and screenshot-heavy manuals, producing semantic Markdown, structured chunks, source maps, and split documents.

The repository includes setup documentation, tests, and public English and Traditional Chinese before/after artifacts. This addition introduces no numeric benchmark claims.

## Link

https://github.com/KingsleyOWO/Semark

## Category

Data Ingestion & Parsing

## Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the repository two-line entry format.
- [x] I added the verified: 2026-07-24 marker.

## Engineering Context

- **Source URL:** https://github.com/KingsleyOWO/Semark
- **Date (YYYY-MM-DD):** 2026-07-24
- **Tag:** Not applicable; no numeric claim is introduced.
- **Methodology / harness link:** Not applicable.
- **Notes:** Self-hosted deployment is supported. MinerU is the parser layer, and local or OpenAI-compatible VLM/LLM endpoints are optional review layers.