### PR TITLE
Add Verbatim Citation Gate to Evaluation & Benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,13 @@ Groundedness, and Answer Relevance.
     LlamaIndex, and DSPy pipelines with feedback functions that score each
     retrieval-and-generation step, emitting OpenTelemetry traces for both
     development debugging and production monitoring.
+- [Verbatim Citation Gate](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)
+  <!-- verified: 2026-07-28 -->
+  - Catches fabricated citations before the answer reaches the user by first
+    checking, with no LLM call, that every quoted span appears verbatim in the
+    retrieved context, then escalating only the survivors to a burden-of-proof
+    judge. Framework-agnostic, so it drops in front of an existing pipeline
+    rather than replacing its evaluator.
 
 ### LLM-as-Judge Evaluation
 


### PR DESCRIPTION
One entry, added to **Evaluation & Benchmarking** in alphabetical order (after TruLens), in the repo's two-line bullet style with a `verified:` marker, no emoji and no bold inline labels.

**Resource:** [Verbatim Citation Gate](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate) — a two-stage check for fabricated citations in RAG answers. Stage one is deterministic and costs no tokens: every quoted span must appear verbatim in the retrieved context, so an invented quote is rejected without an LLM ever being called. Only spans that survive reach stage two, a burden-of-proof judge that has to affirmatively show support rather than merely fail to object.

**Why it fits the production framing:** the existing entries in this section are evaluators you run over a dataset. This one is designed to sit inline in the request path — the cheap stage is a string check, so the expensive judge only sees the residue. It is framework-agnostic and does not replace Ragas or TruLens; it runs in front of them.

**Evidence Tier:** not applicable — this PR introduces no numeric claim (no latency, recall, cost, or hallucination-rate figure). Only a description of what the tool does.

**Against the Selection Criteria:**
- **Actively maintained:** last push 2026-07-24.
- **Documented:** README with install and usage, worked examples for the two stages.
- **Licensing:** MIT, no hosted service or paid backend.

Checked the README and the open PRs for a duplicate; nothing matching. Also read the FAQ to confirm this is not an intentionally excluded category. Happy to move it under **Security & Compliance** instead if you consider a gate closer to a guardrail than to an evaluator.