### PR TITLE
Add Reducto to Data Ingestion & Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ Choose the right framework for your use case with this production-focused compar
     data across 100+ languages. Its PP-StructureV3 pipeline recovers tables,
     formulas, and reading order, providing a self-hostable parsing layer for
     document-heavy RAG ingestion.
+- [Reducto](https://reducto.ai/)
+  <!-- verified: 2026-07-30 -->
+  - Managed document intelligence platform for parsing, extracting, and
+    classifying complex PDFs, spreadsheets, and office files into structured
+    outputs for RAG ingestion.
 - [Unstructured](https://github.com/Unstructured-IO/unstructured)
   - Open-source pipelines for preprocessing complex, unstructured data.
 


### PR DESCRIPTION
# Pull Request

## Description
Adds Reducto to Data Ingestion & Parsing. Reducto is a managed document intelligence platform for parsing, extracting, and classifying complex files into structured outputs for RAG ingestion.

## Link
https://reducto.ai/

## Category
Data Ingestion & Parsing

## Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is public, usable, and documented as a managed API service.
- [x] It solves a real-world production problem.
- [x] The entry follows the repo two-line format from CONTRIBUTING.md.
- [x] For new or substantially edited entries, I added/updated the verified: YYYY-MM-DD marker.

## Engineering Context

- **Source URL:** https://docs.reducto.ai/overview
- **Date (YYYY-MM-DD):** 2026-07-30
- **Tag:** N/A, no numeric claim added.
- **Methodology / harness link:** N/A
- **Notes:** Non-numeric resource addition; verified link, placement, and production relevance. Submitting on behalf of Reducto.