### PR TITLE
Add AutoGraft to GraphRAG section (ingestion-time entity resolution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,9 +664,9 @@ are the main themes?") that standard vector search struggles to address.
     without the full Microsoft GraphRAG dependency footprint.
 - [AutoGraft](https://github.com/jules-gd-dev/autograft-lib)
   <!-- verified: 2026-08-08 -->
-  - A fast, drop-in Python middleware for Neo4j GraphRAG that drastically reduces LLM entity resolution costs.
-    It intercepts nodes from extractors and uses a 3-layer approach (Deterministic B-Tree -> HNSW Vector -> LLM)
-    to prevent duplicates at $O(N \log M)$ complexity.
+  - A fast, drop-in Python middleware for Neo4j GraphRAG that cuts LLM entity-resolution cost ~99.8%.
+    It intercepts nodes from extractors and uses a 3-layer cascade (deterministic fuzzy matching -> vector cosine similarity -> LLM arbiter)
+    to deduplicate entities at ingestion.
 - [LlamaIndex PropertyGraphIndex](https://docs.llamaindex.ai/en/stable/module_guides/indexing/lpg_index_guide/)
   <!-- verified: 2026-08-01 -->
   - First-class knowledge graph indexing within the LlamaIndex ecosystem, and the

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ are the main themes?") that standard vector search struggles to address.
     without the full Microsoft GraphRAG dependency footprint.
 - [AutoGraft](https://github.com/jules-gd-dev/autograft-lib)
   <!-- verified: 2026-08-08 -->
-  - A fast, drop-in Python middleware for Neo4j GraphRAG that cuts LLM entity-resolution cost ~99.8%.
+  - A fast, drop-in Python middleware for Neo4j GraphRAG that cuts LLM entity-resolution cost ~99.8% [A].
     It intercepts nodes from extractors and uses a 3-layer cascade (deterministic fuzzy matching -> vector cosine similarity -> LLM arbiter)
     to deduplicate entities at ingestion.
 - [LlamaIndex PropertyGraphIndex](https://docs.llamaindex.ai/en/stable/module_guides/indexing/lpg_index_guide/)

--- a/README.md
+++ b/README.md
@@ -662,6 +662,11 @@ are the main themes?") that standard vector search struggles to address.
   - A lightweight, hackable implementation of the GraphRAG pipeline (~1k lines).
     Ideal for understanding the algorithm or embedding it into custom systems
     without the full Microsoft GraphRAG dependency footprint.
+- [AutoGraft](https://github.com/jules-gd-dev/autograft-lib)
+  <!-- verified: 2026-08-08 -->
+  - A fast, drop-in Python middleware for Neo4j GraphRAG that drastically reduces LLM entity resolution costs.
+    It intercepts nodes from extractors and uses a 3-layer approach (Deterministic B-Tree -> HNSW Vector -> LLM)
+    to prevent duplicates at $O(N \log M)$ complexity.
 - [LlamaIndex PropertyGraphIndex](https://docs.llamaindex.ai/en/stable/module_guides/indexing/lpg_index_guide/)
   <!-- verified: 2026-08-01 -->
   - First-class knowledge graph indexing within the LlamaIndex ecosystem, and the


### PR DESCRIPTION
Adding AutoGraft to the GraphRAG section, checked against CONTRIBUTING.md's quality standards:

- **Production focus** — addresses a real operational cost: LLM entity resolution at GraphRAG ingestion. On a 500-doc / 3,000-mention benchmark, full-LLM dedup costs $0.0334 vs $0.00008 for AutoGraft's cascade — relevant to the list's FinOps angle.
- **Maintained** — active development (last push 2026-08-09); no staleness risk under the 6-month rule.
- **Documented** — README with quick start + LangChain/LlamaIndex integrations; BENCHMARK.md with reproducible methodology (real embeddings, real Groq LLM calls, real pricing).

It complements the existing GraphRAG implementations: it deduplicates entities at ingestion, before the graph store, rather than competing with retrieval-time approaches.

### Engineering Context

- **Source URL:** https://github.com/jules-gd-dev/autograft-lib/blob/master/BENCHMARK.md
- **Date:** 2026-08-09
- **Tag:** [A]
- **Methodology link:** https://github.com/jules-gd-dev/autograft-lib/blob/master/benchmark/run_real_benchmark.py
