### PR TITLE
Add synthetic industrial manual RAG dataset

### DIFF
--- a/datasets.md
+++ b/datasets.md
@@ -126,7 +126,7 @@ types — spanning bio-medical IR, fact-checking, argument retrieval, and more.
 
 ## Industrial & Field Service
 
-- [Industrial Manual RAG Evaluation Pack](https://github.com/kylecoutray/private-ai-pilot-toolkit/tree/main/assets/industrial-manual-rag-eval)
+- [Industrial Manual RAG Evaluation Pack](https://github.com/kylecoutray/industrial-manual-rag-eval)
   <!-- verified: 2026-08-10 -->
   - Small synthetic corpus with current and superseded manuals,
     neighboring-equipment traps, service-bulletin precedence, restricted and

--- a/datasets.md
+++ b/datasets.md
@@ -124,6 +124,18 @@ types — spanning bio-medical IR, fact-checking, argument retrieval, and more.
 
 ---
 
+## Industrial & Field Service
+
+- [Industrial Manual RAG Evaluation Pack](https://github.com/kylecoutray/private-ai-pilot-toolkit/tree/main/assets/industrial-manual-rag-eval)
+  <!-- verified: 2026-08-10 -->
+  - Small synthetic corpus with current and superseded manuals,
+    neighboring-equipment traps, service-bulletin precedence, restricted and
+    withdrawn sources, twelve expected-answer cases, and critical-failure
+    scoring. Maintained by InHouse Compute; every product and procedure is
+    fictional and not for real equipment.
+
+---
+
 ## Synthetic Data Generation
 
 Don't have a dataset? Generate one from your own internal documents.


### PR DESCRIPTION
# Pull Request

## Description

Adds a small, inspectable industrial and field-service RAG evaluation pack. It exercises production failure modes that general open-domain QA datasets do not: neighboring-model blending, obsolete revisions, scoped service-bulletin precedence, unsupported answers, access leakage, withdrawn sources, and unsafe bypass requests. The corpus and expected-answer cases are public and require no registration.

InHouse Compute maintains the linked resource. The entry discloses that relationship and states that every product and procedure is fictional and not for real equipment. No customer result, performance figure, endorsement, or safety claim is introduced.

## Link

https://github.com/kylecoutray/industrial-manual-rag-eval

## Category

Datasets for RAG Benchmarking — Industrial & Field Service

## Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the repository two-line entry format.
- [x] For new or substantially edited entries, I added/updated the verified date marker.

## Engineering Context

- Source URL: N/A — no numeric performance claim is introduced.
- Date: N/A
- Tag: N/A
- Methodology / harness link: https://github.com/kylecoutray/industrial-manual-rag-eval
- Notes: Twelve fixed expected-behavior cases, six synthetic documents, and a critical-failure scoring guide; no measured result is claimed.