### PR TITLE
Add AI Router to LLM gateway comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,6 +1236,7 @@ and often layers caching on top — without requiring per-provider changes to ap
 | [Helicone](https://github.com/Helicone/helicone) | Self-host / Cloud | OpenAI + Anthropic | Built-in | Fine-grained token analytics | Cost optimization and prompt versioning |
 | [OpenRouter](https://openrouter.ai/) | Managed | 100+ models | — | Per-request | Unified model marketplace, no infra |
 | [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) | Managed (edge) | Major providers | Built-in | Real-time analytics | Edge-deployed, global routing |
+| [AI Router](https://ai-router.dev/) | Managed | OpenAI-compatible catalog | — | Per-key usage visibility | Unified generation and embeddings with model discovery |
 
 - [LiteLLM](https://github.com/BerriAI/litellm)
   - An OpenAI-compatible proxy and SDK wrapper supporting 100+ LLM providers


### PR DESCRIPTION
# Pull Request

## Description

Adds AI Router as one managed service row in the existing LLM Gateways & Routing comparison table.

For production RAG pipelines, it provides an OpenAI-compatible catalog with authenticated model discovery, generation and embeddings through one base URL, plus per-key usage visibility. This is an operator self-submission. The change deliberately does not add a detailed duplicate entry, modify the FinOps section, or introduce pricing, model-count, performance, availability, or benchmark claims.

## Link

https://ai-router.dev/

## Category

LLM Gateways & Routing

## Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The entry follows the existing gateway comparison-table format.
- [x] The verified-marker requirement is not applicable to a table row; the repository validator reports zero findings.

## Engineering Context

- **Source URL:** https://ai-router.dev/docs/protocols/api-endpoints-and-v1/
- **Date (YYYY-MM-DD):** 2026-08-15
- **Tag:** N/A - no numeric claim is added.
- **Methodology / harness link:** N/A - authentication-boundary probes only.
- **Notes:** Verified the website, endpoint documentation, and machine-readable pricing page return HTTP 200. Without credentials, `GET /v1/models` and `POST /v1/chat/completions`, `/v1/responses`, and `/v1/embeddings` each reach the expected HTTP 401 authentication boundary. All six local content-policy checks pass.
