### PR TITLE
fix(links): repoint the Weaviate SLA row at the live tiered SLA

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -171,7 +171,7 @@ confirming this specific figure was found. If you have the original source, plea
 | Provider | Published SLA | Tag | Source | Date |
 | :--- | :--- | :--- | :--- | :--- |
 | Pinecone | 99.95% uptime | \[V\] | [Pinecone Security & Reliability](https://www.pinecone.io/security/) | 2026-08-01 |
-| Weaviate Cloud | 99.9% uptime | \[V\] | [Weaviate SLA](https://weaviate.io/service/sla) | 2024 |
+| Weaviate Cloud | 99.5% / 99.9% / 99.95% uptime per quarter (Flex / Premium shared / Premium dedicated) | \[V\] | [Weaviate SLA](https://weaviate.io/sla) | 2026-05 |
 | Qdrant Cloud | 99.9% uptime | \[V\] | [Qdrant Cloud SLA](https://qdrant.tech/cloud/) | 2024 |
 
 Self-hosted Milvus, Chroma, pgvector, and vLLM have no provider SLA — reliability


### PR DESCRIPTION
# Pull Request

## Description

Closes the Weaviate half of #85 (weekly link audit).

`weaviate.io/service/sla` still answers HTTP 200, which is why it looked
merely flaky — but the response is a 289-byte JavaScript stub that redirects
to `/service`. The SLA document itself now lives at `weaviate.io/sla`.

Following the link back surfaced a stale *claim*, not just a stale URL. The
live SLA (last updated May 2026) commits availability per quarter by tier:

| Tier | Availability per quarter |
| :--- | :--- |
| Flex / Standard | 99.5% |
| Premium shared / Professional | 99.9% |
| Premium dedicated / Business Critical | 99.95% |

The flat `99.9% uptime` row over-promised the entry tier and under-promised
the top one. The row now carries all three figures, the canonical URL, and
the 2026-05 date.

The Qdrant entry in the same issue is a false positive — see the issue thread
for the evidence; no change is proposed here.

## Link

https://weaviate.io/sla

## Category

benchmarks.md § 7 Reliability / SLA

## ✅ Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the format: `[Name](URL) - Description.`
- [x] For new or substantially edited entries, I added/updated the `verified: YYYY-MM-DD` marker (CONTRIBUTING.md § Last Verified Date) — not applicable: this is an evidence-table row, not a list entry, so it carries a Date column instead of a marker.

## Engineering Context

- **Source URL:** https://weaviate.io/sla
- **Date (YYYY-MM-DD):** 2026-05-01
- **Tag:** `[V]` vendor-stated
- **Methodology / harness link:** N/A — a contractual availability commitment, not a measurement.
- **Notes:** Page header reads "Last Updated: May 2026"; the day is not published, so the table records `2026-05`. Figures are quarterly availability commitments, not observed uptime. Free/serverless-free tiers are explicitly excluded from the SLA with no uptime commitment.
