### PR TITLE
chore(triage): clear the August discovery backlog and list two accepts

### DIFF
--- a/.github/DISCOVERY_TRIAGE.md
+++ b/.github/DISCOVERY_TRIAGE.md
@@ -17,6 +17,48 @@ infrastructure building blocks.
 
 ---
 
+## 2026-08-21
+
+Triaged from the 2026-08-03, 2026-08-10, and 2026-08-17 discovery reports
+(16 unique candidates after deduplication across the three cycles).
+
+| Project | Verdict |
+| :--- | :--- |
+| [promptfoo](https://github.com/promptfoo/promptfoo) | **Accepted** — MIT, declarative evals with CLI and CI/CD gating plus adversarial red-teaming; listed under Evaluation & Benchmarking. |
+| [LightRAG](https://github.com/HKUDS/LightRAG) | **Accepted** — the 2026-08-01 deferral is resolved: incremental updates, a server, and pluggable production storage (PostgreSQL, Neo4j, MongoDB, OpenSearch) are now shipped; listed under Retrieval & Reranking § GraphRAG. |
+| [headroom](https://github.com/headroomlabs-ai/headroom) | **Deferred (blocked on a scope decision)** — Apache-2.0 context compression for tool outputs and RAG chunks, actively developed. It is not a cache, so Caching & Performance is the wrong home; listing it means opening a context-compression subsection. That is a maintainer call, not a triage call. |
+| [Graphify](https://github.com/Graphify-Labs/graphify) | **Reject (already rejected)** — same project as `safishamsi/graphify`, moved orgs; a code knowledge graph for coding assistants, explicitly vector-store-free. Both slugs are now on the denylist. |
+| [llm-app](https://github.com/pathwaycom/llm-app) | **Reject** (was Deferred 2026-08-01) — ready-to-run template gallery, not an infrastructure building block. Resolving the deferral so it stops recurring weekly. |
+| [WeKnora](https://github.com/Tencent/WeKnora) | **Reject** — end-user knowledge platform and self-maintaining wiki; out of scope per FAQ. Non-standard license (`NOASSERTION`). |
+| [MaxKB](https://github.com/1Panel-dev/MaxKB) | **Reject** — enterprise agent platform with a visual builder; out of scope per FAQ. |
+| [coze-studio](https://github.com/coze-dev/coze-studio) | **Reject** — all-in-one visual agent development platform; out of scope per FAQ. |
+| [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | **Reject** — end-to-end AI-plus-data assistant product. The Structured & SQL RAG section lists composable pieces (Vanna, WrenAI), not platforms. |
+| [DocsGPT](https://github.com/arc53/DocsGPT) | **Reject** — end-user chat-with-your-documents application; out of scope per FAQ. |
+| [eliza](https://github.com/elizaOS/eliza) | **Reject** — general agentic operating system; agent infrastructure, not RAG infrastructure. |
+| [ai-agent-book](https://github.com/bojieli/ai-agent-book) | **Reject** — book manuscript with companion code; educational, no production-infrastructure focus. |
+| [GenAI_Agents](https://github.com/NirDiamant/GenAI_Agents) | **Reject** — tutorial collection. |
+| [agents-towards-production](https://github.com/NirDiamant/agents-towards-production) | **Reject** — tutorial collection; the production framing is pedagogical, not a shippable component. |
+| [ai-guide](https://github.com/liyupi/ai-guide) | **Reject** — general AI resource collection and beginner tutorials. |
+| [CV](https://github.com/AccumulateMore/CV) | **Reject** — deep-learning lecture notes; not RAG-related at all. |
+
+All rejects above are seeded into `OUT_OF_SCOPE_REPOS` in
+[discovery_engine.py](../scripts/discovery_engine.py) so they stop reappearing.
+
+**Backlog not covered by this triage** — the same reports carry two other
+sections that need separate passes:
+
+- *Stale Benchmark Citations* — 10 rows in `benchmarks.md` older than 365 days.
+  One of them (Weaviate Cloud SLA) was fixed in #86; the other nine still need
+  their sources re-verified or moved to § Gaps.
+- *Stale Listed Tools* — 11 listed repos with no push in over 180 days
+  (byaldi 566d, pachyderm 560d, ARES 507d, prometheus-eval 479d,
+  RAGatouille 457d, GPTCache 402d, tokencost 346d, R2R 283d, omniparse 248d,
+  nano-graphrag 202d, vanna 196d). RAGatouille and GPTCache already carry
+  inline maintenance warnings; the rest need a deprecate-or-keep decision per
+  the Removal & Deprecation Policy.
+
+---
+
 ## 2026-08-01
 
 Triaged from the 2026-07-27 discovery report.

--- a/README.md
+++ b/README.md
@@ -662,6 +662,13 @@ are the main themes?") that standard vector search struggles to address.
   - A lightweight, hackable implementation of the GraphRAG pipeline (~1k lines).
     Ideal for understanding the algorithm or embedding it into custom systems
     without the full Microsoft GraphRAG dependency footprint.
+- [LightRAG](https://github.com/HKUDS/LightRAG)
+  <!-- verified: 2026-08-21 -->
+  - Pairs graph traversal with dual-level vector retrieval and supports
+    incremental updates and selective deletion, so a changed document does not
+    force the full re-indexing pass that batch GraphRAG requires. Runs as a
+    server with pluggable production storage (PostgreSQL, Neo4j, MongoDB,
+    OpenSearch) and built-in Ragas and Langfuse hooks.
 - [LlamaIndex PropertyGraphIndex](https://docs.llamaindex.ai/en/stable/module_guides/indexing/lpg_index_guide/)
   <!-- verified: 2026-08-01 -->
   - First-class knowledge graph indexing within the LlamaIndex ecosystem, and the
@@ -978,6 +985,12 @@ Groundedness, and Answer Relevance.
     your own corpus with statistical IR metrics (Recall/NDCG/MAP/bpref) plus
     paired-bootstrap CIs and Wilcoxon p-values to call architectural winners
     with confidence before you commit infrastructure.
+- [promptfoo](https://github.com/promptfoo/promptfoo)
+  <!-- verified: 2026-08-21 -->
+  - Declarative, config-driven evals that run from the CLI and in CI/CD, so a
+    prompt or model change is gated by assertions instead of eyeballed in a
+    notebook. It also ships adversarial red-teaming and vulnerability scanning,
+    covering the security half of RAG evaluation that quality metrics alone miss.
 - [Ragas](https://github.com/explodinggradients/ragas)
   - A framework that uses an "LLM-as-a-Judge" to evaluate your pipeline. It
     calculates metrics like Faithfulness (did the answer come from the context?)

--- a/scripts/discovery_engine.py
+++ b/scripts/discovery_engine.py
@@ -65,6 +65,13 @@ OUT_OF_SCOPE_REPOS = {
     "labring/fastgpt",
     "onyx-dot-app/onyx",
     "simstudioai/sim",
+    "1panel-dev/maxkb",
+    "coze-dev/coze-studio",
+    "tencent/weknora",
+    "eosphoros-ai/db-gpt",
+    "arc53/docsgpt",
+    # General agent platforms / runtimes — agent infra, not RAG infra.
+    "elizaos/eliza",
     # Meta-lists, tutorials, educational guides (no production-infra focus).
     "shubhamsaboo/awesome-llm-apps",
     "dair-ai/prompt-engineering-guide",
@@ -72,8 +79,16 @@ OUT_OF_SCOPE_REPOS = {
     "datawhalechina/happy-llm",
     "patchy631/ai-engineering-hub",
     "hkuds/deeptutor",
+    "bojieli/ai-agent-book",
+    "nirdiamant/genai_agents",
+    "nirdiamant/agents-towards-production",
+    "accumulatemore/cv",
+    "liyupi/ai-guide",
+    # Template / demo galleries.
+    "pathwaycom/llm-app",
     # Coding-assistant / session-memory plugins (not RAG infra).
     "safishamsi/graphify",
+    "graphify-labs/graphify",
     "thedotmack/claude-mem",
     # General-purpose scrapers — ingestion-adjacent but not RAG infrastructure.
     "scrapegraphai/scrapegraph-ai",


### PR DESCRIPTION
# Pull Request

## Description

Clears the discovery-feed backlog on #54 and lists the two candidates that earn a place.

Three cycles (2026-08-03, 08-10, 08-17) had gone untriaged, so the same 16 candidates were re-reported every Monday — which is exactly how a weekly feed stops being read.

**Accepted and listed here**

- **[promptfoo](https://github.com/promptfoo/promptfoo)** → Evaluation & Benchmarking. MIT, 24.4k stars, released 0.122.0 on 2026-08-04. Declarative eval configs that run from the CLI and gate CI, plus adversarial red-teaming — the security half of RAG evaluation that Ragas/DeepEval do not cover.
- **[LightRAG](https://github.com/HKUDS/LightRAG)** → Retrieval & Reranking § GraphRAG. MIT, 39k stars, pushed daily. Resolves its 2026-08-01 **Deferred** verdict: incremental updates and selective deletion, a server, pluggable production storage (PostgreSQL, Neo4j, MongoDB, OpenSearch), and Ragas/Langfuse hooks are all shipped now. That is what "revisit once production adoption is clearer" was waiting for.

**Still deferred, and this one needs a maintainer decision**

- **[headroom](https://github.com/headroomlabs-ai/headroom)** — Apache-2.0, 67k stars, pushed daily; compresses tool outputs and RAG chunks before they reach the model. It is genuinely production infrastructure, but it is *not a cache*, so Caching & Performance is the wrong home. Listing it means opening a context-compression subsection, which is a scope decision rather than a triage verdict. Flagged, not silently dropped.

**Rejected (12)** — full reasoning in the triage log. All seeded into `OUT_OF_SCOPE_REPOS`.

One of them is worth calling out: **graphify** was already rejected on 2026-08-01 as `safishamsi/graphify`, but the project moved to `Graphify-Labs/graphify`. The denylist matches on full slug, so the rename silently defeated it and an already-rejected repo came back at the top of three consecutive reports. Both slugs are now listed.

**Backlog deliberately not covered here** — the same reports carry two other sections that deserve their own passes, recorded at the bottom of the triage log rather than left implicit:

- 10 stale benchmark citations (>365 days). The Weaviate SLA row was fixed in #86; nine remain.
- 11 listed repos with no push in >180 days, needing a deprecate-or-keep decision per the Removal & Deprecation Policy.

## Link

https://github.com/promptfoo/promptfoo · https://github.com/HKUDS/LightRAG

## Category

README § Evaluation & Benchmarking · README § Retrieval & Reranking (GraphRAG)

## ✅ Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the format: `[Name](URL) - Description.`
- [x] For new or substantially edited entries, I added/updated the `verified: 2026-08-21` marker (CONTRIBUTING.md § Last Verified Date).

## Engineering Context

- **Source URL:** https://github.com/promptfoo/promptfoo · https://github.com/HKUDS/LightRAG
- **Date (YYYY-MM-DD):** 2026-08-21
- **Tag:** N/A — neither entry introduces a numeric performance, cost, or quality claim.
- **Methodology / harness link:** N/A.
- **Notes:** Capability claims were checked against upstream sources rather than the discovery-feed blurb. LightRAG's incremental-update and selective-deletion behaviour and its storage backends are documented in its README; promptfoo's CI/CD gating and red-teaming are documented at promptfoo.dev. The compression percentages in headroom's own description are deliberately not quoted anywhere, since that entry is not being listed.
