### PR TITLE
fix(discovery): match the out-of-scope denylist on repo id, not slug

### DIFF
--- a/scripts/discovery_engine.py
+++ b/scripts/discovery_engine.py
@@ -50,49 +50,102 @@ _SKIP_REPOS = {"awesome", "awesome-list", ".github"}
 
 # Repos repeatedly surfaced by topic:rag but out of scope for this infrastructure
 # list. Seeded from documented "out-of-scope" triage verdicts (see the triage
-# record in .github/DISCOVERY_TRIAGE.md / FAQ § Scope). Matched on lowercased
-# owner/repo. Extend as new noise appears. Note: already-listed repos do NOT
-# belong here — README dedup handles those automatically.
-OUT_OF_SCOPE_REPOS = {
+# record in .github/DISCOVERY_TRIAGE.md / FAQ § Scope).
+#
+# Each entry maps the slug as written at triage time to the repository's GitHub
+# id. The slug is for humans reading the diff; the id is what actually matches.
+# A rejected project that moves org keeps its id but changes its slug, so
+# slug-only matching silently re-admits it: graphify was rejected as
+# safishamsi/graphify on 2026-08-01, moved to Graphify-Labs/graphify, and came
+# back as the top candidate for three consecutive weekly reports. Its id
+# (1200597263) never changed.
+#
+# Adding an entry: `gh api repos/<owner>/<name> --jq .id`. A None id still
+# matches by slug, but loses rename protection and is warned about at run time;
+# tests/test_discovery_engine.py enforces that every entry carries one.
+# Already-listed repos do NOT belong here — README dedup handles those.
+OUT_OF_SCOPE_REPOS: dict[str, int | None] = {
     # End-user apps / low-code platforms.
-    "langgenius/dify",
-    "open-webui/open-webui",
-    "flowiseai/flowise",
-    "mintplex-labs/anything-llm",
-    "jeecgboot/jeecgboot",
-    "khoj-ai/khoj",
-    "cinnamon/kotaemon",
-    "labring/fastgpt",
-    "onyx-dot-app/onyx",
-    "simstudioai/sim",
-    "1panel-dev/maxkb",
-    "coze-dev/coze-studio",
-    "tencent/weknora",
-    "eosphoros-ai/db-gpt",
-    "arc53/docsgpt",
+    "langgenius/dify": 626805178,
+    "open-webui/open-webui": 701547123,
+    "flowiseai/flowise": 621803253,
+    "mintplex-labs/anything-llm": 649170660,
+    "jeecgboot/jeecgboot": 159152904,
+    "khoj-ai/khoj": 396569538,
+    "cinnamon/kotaemon": 777111718,
+    "labring/fastgpt": 605673387,
+    "onyx-dot-app/onyx": 633262635,
+    "simstudioai/sim": 912559512,
+    "1panel-dev/maxkb": 691347156,
+    "coze-dev/coze-studio": 1008726722,
+    "tencent/weknora": 1024118326,
+    "eosphoros-ai/db-gpt": 627480054,
+    "arc53/docsgpt": 596516907,
     # General agent platforms / runtimes — agent infra, not RAG infra.
-    "elizaos/eliza",
+    "elizaos/eliza": 826170402,
     # Meta-lists, tutorials, educational guides (no production-infra focus).
-    "shubhamsaboo/awesome-llm-apps",
-    "dair-ai/prompt-engineering-guide",
-    "datawhalechina/hello-agents",
-    "datawhalechina/happy-llm",
-    "patchy631/ai-engineering-hub",
-    "hkuds/deeptutor",
-    "bojieli/ai-agent-book",
-    "nirdiamant/genai_agents",
-    "nirdiamant/agents-towards-production",
-    "accumulatemore/cv",
-    "liyupi/ai-guide",
+    "shubhamsaboo/awesome-llm-apps": 793375104,
+    "dair-ai/prompt-engineering-guide": 579082810,
+    "datawhalechina/hello-agents": 1052050442,
+    "datawhalechina/happy-llm": 806854629,
+    "patchy631/ai-engineering-hub": 876064934,
+    "hkuds/deeptutor": 1124219907,
+    "bojieli/ai-agent-book": 1053118194,
+    "nirdiamant/genai_agents": 854807707,
+    "nirdiamant/agents-towards-production": 1003143578,
+    "accumulatemore/cv": 476314415,
+    "liyupi/ai-guide": 931950959,
     # Template / demo galleries.
-    "pathwaycom/llm-app",
+    "pathwaycom/llm-app": 668195240,
     # Coding-assistant / session-memory plugins (not RAG infra).
-    "safishamsi/graphify",
-    "graphify-labs/graphify",
-    "thedotmack/claude-mem",
+    # Same repository under both slugs: rejected under the first, moved to the
+    # second. Kept as a pair so the rename stays visible in the source.
+    "safishamsi/graphify": 1200597263,
+    "graphify-labs/graphify": 1200597263,
+    "thedotmack/claude-mem": 1048065319,
     # General-purpose scrapers — ingestion-adjacent but not RAG infrastructure.
-    "scrapegraphai/scrapegraph-ai",
+    "scrapegraphai/scrapegraph-ai": 749126547,
 }
+
+# Ids are what the filter actually matches on; the dict keys stay the readable
+# record of why each repo is here.
+OUT_OF_SCOPE_REPO_IDS = {
+    repo_id for repo_id in OUT_OF_SCOPE_REPOS.values() if repo_id is not None
+}
+
+
+def is_out_of_scope(project: dict) -> bool:
+    """Return True when a search result is on the out-of-scope denylist.
+
+    Matches on the immutable repository id first so a rejected project that
+    changes owner or name stays rejected, and falls back to the slug for
+    entries whose id has not been filled in yet.
+    """
+    if project.get("id") in OUT_OF_SCOPE_REPO_IDS:
+        return True
+    return (project.get("full_name") or "").lower() in OUT_OF_SCOPE_REPOS
+
+
+def filter_candidates(
+    projects: list[dict], listed_slugs: set[str]
+) -> tuple[list[dict], int, int]:
+    """Drop already-listed and out-of-scope repos from search results.
+
+    Returns the surviving projects plus how many were removed by each rule, so
+    the caller can log the split instead of a single opaque total.
+    """
+    kept: list[dict] = []
+    listed_hits = 0
+    denied_hits = 0
+    for project in projects:
+        if (project.get("full_name") or "").lower() in listed_slugs:
+            listed_hits += 1
+            continue
+        if is_out_of_scope(project):
+            denied_hits += 1
+            continue
+        kept.append(project)
+    return kept, listed_hits, denied_hits
 
 
 def _build_session() -> requests.Session:
@@ -565,15 +618,20 @@ def run_discovery() -> None:
     listed = {
         f"{owner}/{repo}".lower() for owner, repo in _listed_repo_slugs(REPO_ROOT)
     }
-    skip = listed | OUT_OF_SCOPE_REPOS
-    new_projects = [
-        p for p in projects if (p.get("full_name") or "").lower() not in skip
-    ]
+    unresolved = [slug for slug, rid in OUT_OF_SCOPE_REPOS.items() if rid is None]
+    if unresolved:
+        log.warning(
+            "Denylist entries without a repo id (slug-only, no rename protection): %s",
+            ", ".join(sorted(unresolved)),
+        )
+
+    new_projects, listed_hits, denied_hits = filter_candidates(projects, listed)
     log.info(
-        "Discovery: %d fetched, %d new after filtering (%d already-listed/out-of-scope removed)",
+        "Discovery: %d fetched, %d new after filtering (%d already listed, %d out of scope)",
         len(projects),
         len(new_projects),
-        len(projects) - len(new_projects),
+        listed_hits,
+        denied_hits,
     )
     candidates = new_projects[:DISPLAY_LIMIT]
 

--- a/tests/test_discovery_engine.py
+++ b/tests/test_discovery_engine.py
@@ -292,3 +292,73 @@ def test_tool_freshness_all_requests_fail_does_not_raise(
     assert report == "", (
         f"No repo could be audited, so nothing to flag, got: {report!r}"
     )
+
+
+# --- Out-of-scope denylist -------------------------------------------------
+#
+# The denylist used to match on `owner/name`. When a rejected project moved
+# org, its slug changed while its id did not, so the entry stopped matching and
+# an already-rejected repo returned to the top of three consecutive weekly
+# reports. These tests pin the id-first behaviour that replaced it.
+
+
+def _search_item(full_name: str, repo_id: int) -> dict[str, Any]:
+    """Return the subset of a GitHub search result the filter actually reads."""
+    return {"id": repo_id, "full_name": full_name}
+
+
+def test_denylisted_repo_still_matches_after_a_rename() -> None:
+    slug, repo_id = next(
+        (slug, rid)
+        for slug, rid in discovery_engine.OUT_OF_SCOPE_REPOS.items()
+        if rid is not None
+    )
+    renamed = _search_item("BrandNewOrg/rebranded-name", repo_id)
+
+    assert discovery_engine.is_out_of_scope(renamed), (
+        f"{slug} moved org and slipped past the denylist; id {repo_id} is unchanged"
+    )
+
+
+def test_denylist_falls_back_to_the_slug_when_the_id_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(discovery_engine.OUT_OF_SCOPE_REPOS, "acme/no-id-yet", None)
+
+    assert discovery_engine.is_out_of_scope(_search_item("Acme/No-Id-Yet", 999_001))
+
+
+def test_repo_absent_from_the_denylist_is_not_filtered() -> None:
+    assert not discovery_engine.is_out_of_scope(
+        _search_item("some-org/genuinely-new", 999_002)
+    )
+
+
+def test_filter_candidates_splits_listed_from_out_of_scope() -> None:
+    denied_id = next(
+        rid for rid in discovery_engine.OUT_OF_SCOPE_REPOS.values() if rid is not None
+    )
+    projects = [
+        _search_item("qdrant/qdrant", 999_003),
+        _search_item("Renamed/still-out-of-scope", denied_id),
+        _search_item("some-org/genuinely-new", 999_004),
+    ]
+
+    kept, listed_hits, denied_hits = discovery_engine.filter_candidates(
+        projects, {"qdrant/qdrant"}
+    )
+
+    assert [p["full_name"] for p in kept] == ["some-org/genuinely-new"]
+    assert (listed_hits, denied_hits) == (1, 1)
+
+
+def test_every_denylist_entry_carries_a_repo_id() -> None:
+    """Ratchet: a slug-only entry silently loses rename protection.
+
+    Fill it in with `gh api repos/<owner>/<name> --jq .id`.
+    """
+    unresolved = sorted(
+        slug for slug, rid in discovery_engine.OUT_OF_SCOPE_REPOS.items() if rid is None
+    )
+
+    assert unresolved == [], f"denylist entries missing a repo id: {unresolved}"


### PR DESCRIPTION
# Pull Request

## Description

Fixes the denylist bug that #87 surfaced. No catalog entries change.

**The bug.** `OUT_OF_SCOPE_REPOS` matched on `owner/name`. A rejected project only had to move org to come back. graphify was rejected on 2026-08-01 as `safishamsi/graphify`, moved to `Graphify-Labs/graphify`, and returned as the **top candidate in three consecutive weekly reports** — with nothing signalling that it was a rename rather than a new project. Both slugs resolve to the same repository:

```
$ gh api repos/safishamsi/graphify   --jq .id   # 1200597263
$ gh api repos/Graphify-Labs/graphify --jq .id  # 1200597263
```

Patching the one slug (as #87 did) fixes that instance and leaves the failure mode intact for every other entry.

**The fix.** The denylist becomes `slug -> id`. The slug stays as the readable record of why a repo is on the list; the id is what matches. GitHub ids are immutable across renames and transfers, so the entry survives both. All 32 existing entries were resolved and filled in.

Behaviour, verified directly:

| Input | Old (slug-only) | New (id-first) |
| :--- | :--- | :--- |
| `{id: 1200597263, full_name: "Graphify-Labs/graphify-v2"}` | not matched | **matched** |

**Not silently strict.** An id of `None` still matches by slug — it just loses rename protection, gets a run-time warning naming the entry, and fails a ratchet test. So a maintainer adding a reject in a hurry is nudged, not blocked.

**Two things fixed along the way**, both of which helped this bug hide:

- Filtering moved out of `run_discovery` into `filter_candidates`, so it is directly testable rather than reachable only through a live API call.
- The run log reported one opaque "already-listed/out-of-scope removed" total. It now separates the two counts. A denylist entry that quietly stopped matching moved a number the log never showed.

**Tests** — 5 new, 87 passing total:

- a denylisted repo still matches after a rename (the actual regression)
- an entry with an unknown id still matches by slug
- an unrelated repo is not filtered
- `filter_candidates` splits listed from out-of-scope counts correctly
- ratchet: every denylist entry carries an id, with the `gh api` command in the failure message

## Link

N/A — tooling change, no catalog entry added.

## Category

`scripts/discovery_engine.py` — weekly discovery feed

## ✅ Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the format: `[Name](URL) - Description.`
- [x] For new or substantially edited entries, I added/updated the `verified: YYYY-MM-DD` marker (CONTRIBUTING.md § Last Verified Date) — not applicable: no catalog entry is touched.

## Engineering Context

- **Source URL:** N/A — no numeric claim is introduced.
- **Date (YYYY-MM-DD):** 2026-08-21
- **Tag:** N/A
- **Methodology / harness link:** `tests/test_discovery_engine.py`
- **Notes:** All 32 ids were resolved with `gh api repos/<slug> --jq .id` on 2026-08-21. The `safishamsi/graphify` and `Graphify-Labs/graphify` keys are deliberately kept as a pair mapping to one id, so the rename stays visible in the source rather than being flattened away.
