### PR TITLE
fix(benchmarks): re-verify the nine stale citations, drop three unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,22 +1184,24 @@ different bottleneck — deploying them in combination yields compounding return
 
 | Tool | Cache Type | Layer | Backend | Best For | Evidence |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) | Prompt prefix | Provider | Anthropic infra | Long system prompts, large contexts | [\[V\]](benchmarks.md#4-caching-prompt--semantic) |
+| [Anthropic Prompt Caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) | Prompt prefix | Provider | Anthropic infra | Long system prompts, large contexts | [\[V\]](benchmarks.md#4-caching-prompt--semantic) |
 | [GPTCache](https://github.com/zilliztech/GPTCache) | Exact + Semantic | Application | Redis / Milvus / SQLite | Reducing duplicate LLM calls | — |
 | [LangChain Cache](https://python.langchain.com/docs/integrations/llm_caching/) | Exact + Semantic | Application | In-memory / Redis / SQLite | LangChain-native pipelines | — |
 | [LiteLLM Cache](https://docs.litellm.ai/docs/proxy/caching) | Exact + Semantic | Gateway | Redis / S3 / Disk | Multi-provider routing with cache | — |
-| [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching) | Prompt prefix | Provider | OpenAI infra | GPT-4o / o-series, shared prefixes | [\[V\]](benchmarks.md#4-caching-prompt--semantic) |
+| [OpenAI Prompt Caching](https://developers.openai.com/api/docs/guides/prompt-caching) | Prompt prefix | Provider | OpenAI infra | GPT-4o / o-series, shared prefixes | [\[V\]](benchmarks.md#4-caching-prompt--semantic) |
 | [RedisVL Semantic Cache](https://github.com/redis/redis-vl-python) | Semantic | Application | Redis Stack | Existing Redis infra, sub-ms lookup | — |
 | [vLLM Automatic Prefix Caching](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html) | KV-cache | Inference engine | GPU memory | Self-hosted RAG, shared system prompts | [\[3P\]](benchmarks.md#5-llm-serving) |
 
 ### Tools
 
-- [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
-  - Provider-side prefix cache for Claude models that delivers up to 90% cost
-    reduction and 85% latency reduction on cached context
-    (\[V\] [Anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) · 2024).
+- [Anthropic Prompt Caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+  <!-- verified: 2026-08-21 -->
+  - Provider-side prefix cache for Claude models that bills cache reads at about
+    10% of the standard input price
+    (\[V\] [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) · 2026-08-01).
     Add a `cache_control` breakpoint in the API request — no infrastructure
-    changes required.
+    changes required. Cache writes carry a premium, so the break-even point is
+    the second read on a 5-minute TTL and the third on a 1-hour TTL.
 - [GPTCache](https://github.com/zilliztech/GPTCache)
   <!-- verified: 2026-08-01 -->
   - A widely referenced open-source semantic cache for LLM applications. It
@@ -1215,11 +1217,13 @@ different bottleneck — deploying them in combination yields compounding return
   - Gateway-level caching across 100+ LLM providers with per-route TTL control,
     Redis/S3/Disk backends, and cache-control headers. Pairs with the LiteLLM
     proxy for a unified cost-management and caching layer.
-- [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching)
+- [OpenAI Prompt Caching](https://developers.openai.com/api/docs/guides/prompt-caching)
+  <!-- verified: 2026-08-21 -->
   - Automatic prefix caching for GPT-4o and o-series models; requires zero code
-    changes and delivers a 50% input-token discount on cache hits
-    (\[V\] [OpenAI announcement](https://openai.com/index/api-prompt-caching/) · 2024-10).
-    Effective when system prompts or retrieved context blocks exceed 1,024 tokens.
+    changes and delivered a 50% input-token discount on cache hits at launch
+    (\[V\] [OpenAI announcement](https://openai.com/index/api-prompt-caching/) · 2024-10),
+    though current docs state the discount varies by model. Effective when system
+    prompts or retrieved context blocks exceed 1,024 tokens.
 - [RedisVL Semantic Cache](https://github.com/redis/redis-vl-python)
   - A Redis Stack–backed semantic cache library with sub-millisecond lookup
     latency. Leverages Redis Vector Sets for similarity search and supports

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -24,7 +24,7 @@
 > a peer-reviewed result does not expire. Vendor docs and leaderboard snapshots
 > are never exempt; the weekly audit flags them once they pass 365 days.
 >
-> *Last reviewed: 2026-08-01*
+> *Last reviewed: 2026-08-21*
 
 ---
 
@@ -44,16 +44,19 @@ but no independent reproduction exists, the `[V]` tag is the disclosure mechanis
 
 | System | Dataset | Recall@10 | p99 Latency | Tag | Source | Date | Methodology |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| Qdrant | gist-960-euclidean | 0.990 | ~1 ms (RPS-optimised) | \[V\] | [qdrant.tech/benchmarks](https://qdrant.tech/benchmarks/) | 2024 | [Benchmark FAQ](https://qdrant.tech/benchmarks/benchmark-faq/) — open-source, reproducible |
-| Qdrant | dbpedia-openai-1M-1536-angular | 0.990 | ~2 ms | \[V\] | [qdrant.tech/benchmarks](https://qdrant.tech/benchmarks/) | 2024 | Same as above |
-| Milvus | ANN benchmarks (SIFT-128) | ~0.995 | varies by index | \[V\] | [milvus.io/docs/benchmark.md](https://milvus.io/docs/benchmark.md) | 2024 | VectorDBBench open harness |
-| All major systems | SIFT-1M | 0.95–0.99 | 1–20 ms (HNSW) | \[3P\] | [ann-benchmarks.com](https://ann-benchmarks.com/) | 2024 | [github.com/erikbern/ann-benchmarks](https://github.com/erikbern/ann-benchmarks) — standardized, reproducible |
+| Qdrant | gist-960-euclidean | 0.990 | ~1 ms (RPS-optimised) | \[V\] | [qdrant.tech/benchmarks](https://qdrant.tech/benchmarks/) | 2024-06-15 | [Benchmark FAQ](https://qdrant.tech/benchmarks/benchmark-faq/) — open-source, reproducible |
+| Qdrant | dbpedia-openai-1M-1536-angular | 0.990 | ~2 ms | \[V\] | [qdrant.tech/benchmarks](https://qdrant.tech/benchmarks/) | 2024-06-15 | Same as above |
+| All major systems | SIFT-1M | 0.95–0.99 | 1–20 ms (HNSW) | \[3P\] | [ann-benchmarks.com](https://ann-benchmarks.com/) | 2026-07-10 | [github.com/erikbern/ann-benchmarks](https://github.com/erikbern/ann-benchmarks) — standardized, reproducible |
 
-**Note:** Both the Qdrant and Milvus rows above are **vendor-published**
-benchmarks. For independent reproduction, use
+**Note:** The Qdrant rows above are **vendor-published** benchmarks, last
+re-run 2024-06-15. For independent reproduction, use
 [ANN-Benchmarks](https://ann-benchmarks.com/). Recall@10 depends heavily on HNSW
 `ef_search`; tuning for throughput vs. recall is a production trade-off, not a
 fixed property of the system.
+
+A Milvus recall row previously sat here citing the Milvus benchmark report. That
+report measures QPS and response time only and publishes no recall figure, so the
+row moved to [§ Gaps](#9-gaps--not-publicly-measured).
 
 ### 1b. Scale & Cost
 
@@ -115,14 +118,17 @@ smaller. No single number applies universally — evaluate on your own corpus
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | Anthropic (Claude) | Input token cost on cache hit | ~10% of standard price (−90%) | \[V\] | [Anthropic Prompt Caching Docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) | 2026-08-01 | Requires a `cache_control` breakpoint. Cache TTL is 5 min by default, 1 h optional |
 | Anthropic (Claude) | Cache *write* cost premium | 1.25× standard price (5 min TTL), 2× (1 h TTL) | \[V\] | [Anthropic Prompt Caching Docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) | 2026-08-01 | The break-even point: 5-min TTL pays off from the second read, 1-h TTL from the third |
-| Anthropic (Claude) | Latency reduction on cache hit | Up to −85% | \[V\] | [Anthropic Prompt Caching Docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) | 2024 (active doc) | Long-context prompts; figures are upper-bound under ideal conditions. Not re-verified — see [§ Gaps](#9-gaps--not-publicly-measured) |
-| OpenAI (GPT-4o / o-series) | Input token price on cache hit | 50% discount | \[V\] | [OpenAI Prompt Caching](https://openai.com/index/api-prompt-caching/) | 2024-10 | Automatic, no code changes; min. 1,024 cached tokens |
-| OpenAI (GPT-4o / o-series) | Latency reduction on cache hit | Up to −80% | \[V\] | [OpenAI Prompt Caching Docs](https://platform.openai.com/docs/guides/prompt-caching) | 2024-10 | Input-token processing overhead removed |
+| OpenAI (GPT-4o / o-series) | Input token price on cache hit | 50% discount | \[V\] | [OpenAI Prompt Caching](https://openai.com/index/api-prompt-caching/) | 2024-10 | Automatic, no code changes; min. 1,024 cached tokens. The 2024 announcement figure; current [docs](https://developers.openai.com/api/docs/guides/prompt-caching) state discounts vary by model — check the pricing page for the model you serve |
 
-**All four rows above are vendor-stated `[V]`.** No independent third-party
+**All rows above are vendor-stated `[V]`.** No independent third-party
 reproduction of these caching figures exists in the public literature at time of
-writing. They represent what the provider claims under optimal conditions (high
-cache-hit rate, long shared prefix). See
+writing, and they represent what the provider claims under optimal conditions
+(high cache-hit rate, long shared prefix).
+
+Two latency rows — Anthropic "up to −85%" and OpenAI "up to −80%" — were removed
+on 2026-08-21. Neither figure appears anywhere in the provider documentation the
+rows cited; both providers describe the latency benefit only qualitatively and
+commit to numbers on price alone. The claims moved to
 [§ Gaps](#9-gaps--not-publicly-measured).
 
 ### 4b. Semantic Caching (Application Layer)
@@ -157,7 +163,7 @@ evidence, not exact benchmarks.
 
 | Company | System | Reported Result | Tag | Source | Date |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Discord | Trillion-message search (ANN + Rust + ScyllaDB) | ANN search at trillions-of-messages scale | \[A\] | [Discord Engineering Blog](https://discord.com/blog/how-discord-stores-trillions-of-messages) | 2023 |
+| Discord | Trillion-message search (ANN + Rust + ScyllaDB) | ANN search at trillions-of-messages scale | \[A\] | [Discord Engineering Blog](https://discord.com/blog/how-discord-stores-trillions-of-messages) | 2023-03-06 |
 | LinkedIn | Conversational job search (in-house VDB + BERT) | Member-personalized recommendations at LinkedIn scale | \[A\] | [LinkedIn Engineering Blog](https://engineering.linkedin.com/blog) | Ongoing — no specific post with RAG metrics confirmed |
 
 **Important caveat:** The Shopify "18% → 4% hallucination reduction" figure has been moved to
@@ -172,7 +178,7 @@ confirming this specific figure was found. If you have the original source, plea
 | :--- | :--- | :--- | :--- | :--- |
 | Pinecone | 99.95% uptime | \[V\] | [Pinecone Security & Reliability](https://www.pinecone.io/security/) | 2026-08-01 |
 | Weaviate Cloud | 99.5% / 99.9% / 99.95% uptime per quarter (Flex / Premium shared / Premium dedicated) | \[V\] | [Weaviate SLA](https://weaviate.io/sla) | 2026-05 |
-| Qdrant Cloud | 99.9% uptime | \[V\] | [Qdrant Cloud SLA](https://qdrant.tech/cloud/) | 2024 |
+| Qdrant Cloud | 99.5% / 99.9% / up to 99.95% uptime per quarter (Standard / Premium / Premium Multi-AZ) | \[V\] | [Qdrant Cloud SLA](https://cloud.qdrant.io/sla) | 2026-08-21 |
 
 Self-hosted Milvus, Chroma, pgvector, and vLLM have no provider SLA — reliability
 is entirely operator-managed. RTO/RPO figures are not publicly disclosed by any
@@ -245,6 +251,23 @@ data is itself information engineers need when making sourcing decisions.
   Weaviate Cloud, Zilliz) is not publicly listed in a comparable format. Vendors
   use different unit structures (storage vs. compute vs. pod size). Contact vendors
   for sizing quotes.
+
+- **Milvus recall on SIFT-128** was listed in [§1a](#1a-recall--latency-single-node-hnsw)
+  as ~0.995, cited to the
+  [Milvus benchmark report](https://milvus.io/docs/benchmark.md). Re-reading that
+  report on 2026-08-21 found it publishes QPS and response time only — it contains
+  no recall figure, and it covers Milvus 2.2 rather than a current release. The
+  row was removed. A comparable Milvus recall number would need a
+  [VectorDBBench](https://github.com/zilliztech/VectorDBBench) run with the index
+  parameters stated.
+
+- **Prompt-caching latency reduction** is quoted across the community as "up to
+  −85%" (Anthropic) and "up to −80%" (OpenAI). Neither number appears in the
+  provider documentation those claims cite: both describe faster prompt processing
+  qualitatively and commit to figures only on price. The cost rows in
+  [§4a](#4a-provider-side-prompt-caching) are documented and stay; the latency rows
+  were removed on 2026-08-21. If a provider publishes a measured latency figure,
+  open a PR with the full Evidence Tier.
 
 - **Reranking latency overhead** in production pipelines (round-trip to Cohere
   Rerank API, or BGE-Reranker on CPU/GPU) has not been benchmarked publicly under


### PR DESCRIPTION
# Pull Request

## Description

Closes #90. All nine flagged rows re-read against their sources. Three numbers did not survive.

### Removed — the citation does not support the claim

**Milvus recall on SIFT-128 (~0.995).** The cited page is titled *Milvus 2.2 Benchmark Test Report*. It publishes QPS and TP50/TP99 response time and **no recall figure at all**; it covers Milvus 2.2 against 2.1 rather than a current release; and VectorDBBench appears on it only as a link in an unrelated whitepaper, not as the harness. Three of the row's six fields were wrong. Moved to § Gaps with a note on what a replacement would need.

**Prompt-caching latency, both providers.** "Up to −85%" (Anthropic) and "up to −80%" (OpenAI) are widely repeated with a vendor link attached. Neither figure appears anywhere in the documentation the rows cited — both providers describe the latency benefit qualitatively and commit to numbers only on price. The Anthropic row had already flagged itself *"Not re-verified — see § Gaps"*; this re-verifies it, and the answer is that the number was never there. Both moved to § Gaps. The cost rows are documented and stay.

### Corrected

**Qdrant Cloud SLA** repeated the exact pattern #86 found at Weaviate: a flat `99.9%` cited to `qdrant.tech/cloud/`, a marketing page. The real SLA at `cloud.qdrant.io/sla` commits per tier — 99.5% Standard, 99.9% Premium, up to 99.95% Premium Multi-AZ, measured quarterly. Two out of three rows in that table were single numbers standing in for tiered commitments, so the table was systematically over- or under-promising depending on which plan a reader was on.

**Two provider doc URLs had moved** without the entries following: `docs.anthropic.com` → `platform.claude.com`, and `platform.openai.com/docs` → `developers.openai.com`. Both still resolve through redirects, so no link checker would flag them. Updated with verified markers. The OpenAI entry now notes the discount varies by model, which the current docs say and the 2024 announcement does not.

### Re-dated — accurate, just imprecise

The remaining rows were correct; a bare year was what kept them in the report.

| Row | Was | Now | Basis |
| :--- | :--- | :--- | :--- |
| Qdrant gist-960 / dbpedia | `2024` | `2024-06-15` | The benchmark page's own last-run date |
| ann-benchmarks SIFT-1M | `2024` | `2026-07-10` | Regenerated continuously; repo last pushed then |
| Discord case study | `2023` | `2023-03-06` | The post's publication date |

`Last reviewed` on `benchmarks.md` moves to 2026-08-21.

### Note on what stays flagged

The Qdrant rows will keep appearing in the weekly audit — they are vendor benchmarks past 365 days, and the file's own reading rule says vendor sources are never exempt from staleness. That is working as designed: the audit asks for a re-read, and a re-read is what happened here. It is not a signal to add a `(paper)` exemption, which is reserved for peer-reviewed results.

## Link

https://cloud.qdrant.io/sla · https://developers.openai.com/api/docs/guides/prompt-caching · https://platform.claude.com/docs/en/build-with-claude/prompt-caching

## Category

benchmarks.md §1a, §4a, §6, §7, §9 · README § Caching & Performance

## ✅ Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the format: `[Name](URL) - Description.`
- [x] For new or substantially edited entries, I added/updated the `verified: 2026-08-21` marker (CONTRIBUTING.md § Last Verified Date) — added to both README caching entries whose URLs changed.

## Engineering Context

- **Source URL:** https://cloud.qdrant.io/sla · https://qdrant.tech/benchmarks/ · https://ann-benchmarks.com/ · https://openai.com/index/api-prompt-caching/ · https://discord.com/blog/how-discord-stores-trillions-of-messages
- **Date (YYYY-MM-DD):** 2026-08-21
- **Tag:** `[V]` for the Qdrant SLA and benchmark rows; `[3P]` for ann-benchmarks; `[A]` for the Discord case study. Unchanged from the existing rows.
- **Methodology / harness link:** https://qdrant.tech/benchmarks/benchmark-faq/ · https://github.com/erikbern/ann-benchmarks
- **Notes:** Every source was fetched and read on 2026-08-21, not inferred from the previous row. The Qdrant SLA document publishes no revision date, so its Date records the verification date — the same convention the Pinecone row already uses. `milvus.io` serves a cookie-setting redirect that loops for clients without a cookie jar; the page is reachable in a browser, so this is not a dead link, but it does mean a plain link check never sees its content.
