### PR TITLE
fix(catalog): decide the eleven stale listed tools, and see archived repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,9 +333,13 @@ Choose the right framework for your use case with this production-focused compar
     "Always-Live" RAG by syncing vector indices in real-time as the underlying
     data source changes, without full re-indexing.
 - [R2R](https://github.com/SciPhi-AI/R2R)
-  - A production-ready agentic retrieval system with a RESTful API, multimodal
-    ingestion, hybrid search, and an automatic knowledge-graph pipeline — designed
-    to ship RAG-powered applications without building infrastructure from scratch.
+  <!-- verified: 2026-08-21 -->
+  - An agentic retrieval system with a RESTful API, multimodal ingestion, hybrid
+    search, and an automatic knowledge-graph pipeline — designed to ship
+    RAG-powered applications without building infrastructure from scratch.
+    Upstream has been quiet since late 2025 with no release since v3.6.5
+    (2025-06); pin your version and check maintenance status before adopting it
+    for new work.
 - [RAGFlow](https://github.com/infiniflow/ragflow)
   - An end-to-end RAG engine designed for deep document understanding. It handles
     complex layouts (PDFs, tables, images) natively and includes a built-in
@@ -365,8 +369,11 @@ Choose the right framework for your use case with this production-focused compar
 - [Marker](https://github.com/datalab-to/marker)
   - High-efficiency PDF, EPUB to Markdown converter using vision models.
 - [OmniParse](https://github.com/adithya-s-k/omniparse)
+  <!-- verified: 2026-08-21 -->
   - Universal parser for ingesting any data type (documents, multimedia, web)
-    into RAG-ready formats.
+    into RAG-ready formats. Upstream has been quiet since late 2025 and the
+    project has never cut a tagged release; for a maintained alternative in the
+    same slot see OpenDataLoader PDF or PaddleOCR below.
 - [OpenDataLoader PDF](https://github.com/opendataloader-project/opendataloader-pdf)
   <!-- verified: 2026-08-01 -->
   - Apache-2.0 PDF parser that emits AI-ready structured output while checking
@@ -538,7 +545,7 @@ when a model change degrades retrieval quality.
     promoting to production. Also see LanceDB's built-in versioning for
     vector-native branching (listed in [Vector Databases](#vector-databases)).
 - [Pachyderm](https://github.com/pachyderm/pachyderm)
-  <!-- verified: 2026-08-01 -->
+  <!-- verified: 2026-08-21 -->
   - A data-versioned pipeline orchestration platform. Every pipeline run is
     tied to an immutable data commit, giving full lineage from source document
     to vector index to LLM response — useful in compliance-heavy domains.
@@ -641,7 +648,7 @@ zero-shot retrieval performance.
     and SQL top-k query APIs. It can provide the keyword retrieval leg for
     Postgres-based hybrid RAG stacks.
 - [RAGatouille](https://github.com/AnswerDotAI/RAGatouille)
-  <!-- verified: 2026-08-01 -->
+  <!-- verified: 2026-08-21 -->
   - A library that makes ColBERT (Contextualized Late Interaction over BERT)
     easy to use. ColBERT offers fine-grained token-level matching, providing
     superior retrieval quality compared to standard single-vector dense
@@ -659,9 +666,12 @@ are the main themes?") that standard vector search struggles to address.
     community-aware knowledge graph from documents, enabling both local
     (entity-centric) and global (theme-level) queries with LLM-generated summaries.
 - [nano-graphrag](https://github.com/gusye1234/nano-graphrag)
+  <!-- verified: 2026-08-21 -->
   - A lightweight, hackable implementation of the GraphRAG pipeline (~1k lines).
     Ideal for understanding the algorithm or embedding it into custom systems
-    without the full Microsoft GraphRAG dependency footprint.
+    without the full Microsoft GraphRAG dependency footprint. Listed as a
+    reference implementation rather than a dependency: it is deliberately small
+    and finished, and upstream has been quiet since early 2026.
 - [LightRAG](https://github.com/HKUDS/LightRAG)
   <!-- verified: 2026-08-21 -->
   - Pairs graph traversal with dual-level vector retrieval and supports
@@ -894,7 +904,7 @@ pipeline and preserving layout information that text extraction destroys.
 
 | Tool | Best For | Modalities | Retrieval Style | Production Maturity | Evidence |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| [Byaldi](https://github.com/AnswerDotAI/byaldi) | Quick ColPali deployment | Document pages (image) | Late interaction | Early Production | — |
+| [Byaldi](https://github.com/AnswerDotAI/byaldi) | Quick ColPali deployment | Document pages (image) | Late interaction | Unmaintained since 2025-01 | — |
 | [ColPali](https://github.com/illuin-tech/colpali) | Layout-rich PDF retrieval | Document pages (image) | Late interaction | Research → Production | [\[3P\]](benchmarks.md#9-gaps--not-publicly-measured) |
 | [Jina CLIP v2](https://huggingface.co/jinaai/jina-clip-v2) | Multilingual vision search | Text + Image | Bi-encoder | Production | — |
 | [LlamaIndex Multi-Modal](https://docs.llamaindex.ai/en/stable/module_guides/models/multi_modal/) | End-to-end multimodal RAG | Text + Image | Framework module | Production | — |
@@ -905,7 +915,7 @@ pipeline and preserving layout information that text extraction destroys.
 ### Frameworks & Tools
 
 - [Byaldi](https://github.com/AnswerDotAI/byaldi)
-  <!-- verified: 2026-08-01 -->
+  <!-- verified: 2026-08-21 -->
   - A thin, production-friendly wrapper around ColPali that provides a simple
     index/query API for late-interaction vision-document retrieval. The fastest
     path to deploying ColPali without writing research code. Upstream has been
@@ -975,10 +985,14 @@ document collections.
 ### Frameworks & Tools
 
 - [Vanna](https://github.com/vanna-ai/vanna)
+  <!-- verified: 2026-08-21 -->
   - A Python framework for accurate Text-to-SQL generation using LLMs with
     agentic retrieval. It trains a retrieval model on your schema, DDL, and
     prior question-SQL pairs so queries stay faithful to the actual database
-    structure rather than hallucinating columns or table names.
+    structure rather than hallucinating columns or table names. The repository
+    was archived in February 2026 immediately after the 2.0 release, with no
+    successor named; the code is MIT and still installable, but it will not
+    receive fixes. For new work prefer [WrenAI](https://github.com/Canner/WrenAI).
 - [WrenAI](https://github.com/Canner/WrenAI)
   - An open-source context layer that enriches SQL generation with business
     semantics, examples, and governance rules — enabling AI agents to query
@@ -1050,7 +1064,7 @@ This approach scales better than human evaluation and provides consistent, autom
 **Core Frameworks:**
 
 - [ARES (Automated RAG Evaluation System)](https://github.com/stanford-futuredata/ARES)
-  <!-- verified: 2026-08-01 -->
+  <!-- verified: 2026-08-21 -->
   - Stanford's research project that fine-tunes small LLMs as judges specifically
     for RAG evaluation, targeting frontier-model judge accuracy at a fraction of
     the cost. A research codebase — upstream activity has been sparse since 2025;
@@ -1069,11 +1083,14 @@ This approach scales better than human evaluation and provides consistent, autom
     and embedding distance. Seamlessly integrates with LangSmith for
     production monitoring.
 - [Prometheus](https://github.com/prometheus-eval/prometheus-eval)
-  <!-- verified: 2026-08-01 -->
+  <!-- verified: 2026-08-21 -->
   - An open-source LLM specifically trained for evaluation tasks. Unlike calling a
     frontier model as a judge, Prometheus is optimized for scoring consistency and
     can run locally for cost-sensitive deployments. Use the `prometheus-eval`
     repository — the original `prometheus` repo has had no commits since 2023.
+    Note that `prometheus-eval` has itself been quiet since mid-2025; the
+    released model weights remain usable, but treat the harness as a research
+    artifact rather than a maintained dependency.
 
 **Key Metrics:**
 
@@ -1203,12 +1220,13 @@ different bottleneck — deploying them in combination yields compounding return
     changes required. Cache writes carry a premium, so the break-even point is
     the second read on a 5-minute TTL and the third on a 1-hour TTL.
 - [GPTCache](https://github.com/zilliztech/GPTCache)
-  <!-- verified: 2026-08-01 -->
+  <!-- verified: 2026-08-21 -->
   - A widely referenced open-source semantic cache for LLM applications. It
     intercepts LLM calls, runs similarity search over a cache store, and returns
     hits without calling the model — with pluggable similarity functions, eviction
-    policies, and storage backends (Redis, Milvus, SQLite). Upstream commit
-    activity has slowed considerably; verify maintenance status before adopting.
+    policies, and storage backends (Redis, Milvus, SQLite). Upstream has had no
+    commits since mid-2025 and no release since 2024-08; verify maintenance
+    status before adopting.
 - [LangChain Cache](https://python.langchain.com/docs/integrations/llm_caching/)
   - Built-in exact-match and semantic LLM caching across a broad backend matrix
     (in-memory, Redis, SQLite, MongoDB, Cassandra, GPTCache). One-line setup for
@@ -1356,11 +1374,15 @@ before — not after — cost becomes a budget crisis.
 | [Helicone](https://github.com/Helicone/helicone) | Observability + cost attribution | Fine-grained token analytics per user, team, or feature (see [LLM Gateways](#llm-gateways--routing)) |
 
 - [tokencost](https://github.com/AgentOps-AI/tokencost)
-  - A lightweight Python library that counts tokens and looks up the current
+  <!-- verified: 2026-08-21 -->
+  - A lightweight Python library that counts tokens and looks up the
     price-per-token for 400+ LLM models without making a live API call. Useful
     for pre-flight cost estimation in CI pipelines, budget guardrails, and
     prompt optimization loops — ensure a context window fits a cost budget
-    before it reaches production.
+    before it reaches production. Its last release was 2025-08 and upstream has
+    been quiet since; a bundled price table that stops tracking provider pricing
+    is worse than no table, so verify the models you care about against current
+    provider pricing before trusting a budget guardrail built on it.
 - [OpenMeter](https://github.com/openmeterio/openmeter)
   - An open-source usage metering and billing platform. Ingests usage events
     (token counts, API calls, compute seconds) and exposes per-customer,

--- a/scripts/discovery_engine.py
+++ b/scripts/discovery_engine.py
@@ -329,9 +329,15 @@ def check_listed_tool_freshness(repo_root: Path) -> None:
     """Audit GitHub repos already listed in README.md for staleness.
 
     Extracts all github.com/{owner}/{repo} URLs from README.md, queries the
-    GitHub API for each repo's last push date, and appends a warning table to
-    PROPOSED_UPDATES.md for any repo that hasn't been pushed to in the last
-    STALE_TOOL_DAYS days (aligned with CONTRIBUTING's 6-month activity rule).
+    GitHub API for each repo, and appends warning tables to PROPOSED_UPDATES.md
+    for repos that are archived upstream, or that have not been pushed to in the
+    last STALE_TOOL_DAYS days (aligned with CONTRIBUTING's 6-month activity rule).
+
+    Archived repos get their own table and are never folded into the push-age
+    one. A project can archive right after shipping a release and so read as only
+    mildly quiet — Vanna archived in 2026-02 and surfaced at 200 days, the
+    mildest number in that week's report — which hides the strongest removal
+    signal the Removal & Deprecation Policy recognises behind the weakest one.
 
     Skips the repo's own organisation link and the canonical awesome-list badge.
     Exits silently when README.md is absent or no stale tools are found.
@@ -353,6 +359,7 @@ def check_listed_tool_freshness(repo_root: Path) -> None:
     today = datetime.date.today()
     stale_threshold = today - datetime.timedelta(days=STALE_TOOL_DAYS)
     stale_tools: list[tuple[str, str, int]] = []  # (owner/repo, url, days_since_push)
+    archived_tools: list[tuple[str, str, str]] = []  # (owner/repo, url, last_push)
 
     session = _build_session()
     # Sentinel: every request in the loop below may raise, leaving no response to
@@ -377,6 +384,18 @@ def check_listed_tool_freshness(repo_root: Path) -> None:
             continue
 
         pushed_raw: str = (data.get("pushed_at") or "")[:10]
+
+        if data.get("archived"):
+            archived_tools.append(
+                (
+                    f"{owner}/{repo}",
+                    f"https://github.com/{owner}/{repo}",
+                    pushed_raw or "unknown",
+                )
+            )
+            log.warning("Archived listed tool: %s/%s", owner, repo)
+            continue
+
         if not pushed_raw:
             continue
         try:
@@ -403,12 +422,37 @@ def check_listed_tool_freshness(repo_root: Path) -> None:
     )
     log.info("GitHub API rate limit remaining after tool audit: %s", remaining)
 
-    if not stale_tools:
+    if not stale_tools and not archived_tools:
         log.info("Tool freshness check: all listed repos are current.")
         return
 
     output_path = repo_root / ".github" / "PROPOSED_UPDATES.md"
+    # The two sibling audits already do this; this one did not, so its report was
+    # lost whenever it ran before anything had created .github/.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     try:
+        if archived_tools:
+            with output_path.open("a", encoding="utf-8") as fh:
+                fh.write("\n\n## Archived Listed Tools\n\n")
+                fh.write(
+                    f"> Detected {len(archived_tools)} repo(s) in `README.md` that are "
+                    f"archived on GitHub. Archival is an explicit end-of-life signal, so "
+                    f"these need a decision regardless of how recently they were pushed "
+                    f"to — see the [Removal & Deprecation Policy]"
+                    f"({REPO_BLOB}/CONTRIBUTING.md#removal--deprecation-policy).\n\n"
+                )
+                fh.write("| Repo | Last Push | URL |\n")
+                fh.write("| :--- | :--- | :--- |\n")
+                for slug, url, last_push in archived_tools:
+                    fh.write(f"| {slug} | {last_push} | {url} |\n")
+            log.warning(
+                "Tool freshness: %d archived repo(s) flagged in PROPOSED_UPDATES.md",
+                len(archived_tools),
+            )
+
+        if not stale_tools:
+            return
+
         with output_path.open("a", encoding="utf-8") as fh:
             fh.write(
                 f"\n\n## Stale Listed Tools (>{STALE_TOOL_DAYS} days since last push)\n\n"

--- a/tests/test_discovery_engine.py
+++ b/tests/test_discovery_engine.py
@@ -362,3 +362,91 @@ def test_every_denylist_entry_carries_a_repo_id() -> None:
     )
 
     assert unresolved == [], f"denylist entries missing a repo id: {unresolved}"
+
+
+# --- Archived listed tools -------------------------------------------------
+#
+# The audit read `pushed_at` only. Vanna archived in 2026-02 right after a
+# release, so it surfaced as merely 200 days quiet — the mildest entry in that
+# week's table — while archival is the strongest removal signal the policy has.
+
+
+class _StubSession:
+    """Returns one canned GitHub API payload for every repo lookup."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def get(self, *args: Any, **kwargs: Any) -> Any:
+        payload = self._payload
+
+        class _Response:
+            status_code = 200
+            headers: dict[str, str] = {}
+
+            @staticmethod
+            def raise_for_status() -> None:
+                return None
+
+            @staticmethod
+            def json() -> dict[str, Any]:
+                return payload
+
+        return _Response()
+
+
+def _one_tool_repo(tmp_path: Path) -> Path:
+    return _make_repo(
+        tmp_path,
+        "- [Vanna](https://github.com/vanna-ai/vanna)\n  - Text-to-SQL framework.\n",
+    )
+
+
+def test_archived_repo_is_reported_even_when_recently_pushed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Archival must not be hidden behind a fresh push date."""
+    today = datetime.date.today().isoformat()
+    monkeypatch.setattr(
+        discovery_engine,
+        "_build_session",
+        lambda: _StubSession({"archived": True, "pushed_at": f"{today}T00:00:00Z"}),
+    )
+
+    discovery_engine.check_listed_tool_freshness(_one_tool_repo(tmp_path))
+
+    report = _report(tmp_path)
+    assert "## Archived Listed Tools" in report, report
+    assert "vanna-ai/vanna" in report
+
+
+def test_archived_repo_is_not_also_listed_as_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One repo, one verdict — archival supersedes push age."""
+    monkeypatch.setattr(
+        discovery_engine,
+        "_build_session",
+        lambda: _StubSession({"archived": True, "pushed_at": "2020-01-01T00:00:00Z"}),
+    )
+
+    discovery_engine.check_listed_tool_freshness(_one_tool_repo(tmp_path))
+
+    report = _report(tmp_path)
+    assert "## Archived Listed Tools" in report
+    assert "Stale Listed Tools" not in report, report
+
+
+def test_active_repo_produces_no_archived_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    today = datetime.date.today().isoformat()
+    monkeypatch.setattr(
+        discovery_engine,
+        "_build_session",
+        lambda: _StubSession({"archived": False, "pushed_at": f"{today}T00:00:00Z"}),
+    )
+
+    discovery_engine.check_listed_tool_freshness(_one_tool_repo(tmp_path))
+
+    assert _report(tmp_path) == ""


### PR DESCRIPTION
# Pull Request

## Description

Closes #91. All eleven entries re-read against upstream on 2026-08-21. None had a release cadence that rescued it — the most recent release across the whole set is Vanna's, and Vanna is archived.

### The one that mattered

**Vanna** archived in 2026-02, immediately after shipping 2.0, with no successor named. It was the first tool under Structured & SQL RAG, so readers were being pointed at a project that had stopped. The policy points two ways — hard removal is allowed for archived repos, soft deprecation preferred for widely referenced ones — and at 23.8k stars with an MIT-licensed, still-installable 2.0 it lands on the second. The entry stays, says it is archived, and points at WrenAI, which already sits directly beneath it.

### Four entries had no note at all

| Entry | Note added |
| :--- | :--- |
| tokencost | Last release 2025-08. Sharpest wording of the set: a bundled price table that stops tracking provider pricing is worse than no table, because it fails **silently** inside a budget guardrail. |
| R2R | Quiet since late 2025, no release since v3.6.5 (2025-06). Pin your version. |
| OmniParse | Quiet since late 2025, never cut a tagged release. Points at OpenDataLoader PDF and PaddleOCR in the same section. |
| nano-graphrag | Gentlest of the four. A ~1k-line reference implementation being finished is a normal end state, not decay — the entry now says it is listed as a reference, not a dependency. |

### Three existing notes had gone wrong

- **Prometheus** told readers to use `prometheus-eval` instead of the dead `prometheus` repo. `prometheus-eval` has itself been quiet since mid-2025 — the note walked readers from one dormant repo to another. Now says so.
- **GPTCache**'s "activity has slowed considerably" understated 13 months of silence and no release since 2024-08.
- **Byaldi**'s comparison-table row claimed **"Early Production"** maturity for a repo untouched since 2025-01. Now reads "Unmaintained since 2025-01".

Pachyderm, ARES, and RAGatouille were re-read and their notes are still accurate. All five pre-existing markers move to `verified: 2026-08-21`, since a human did in fact check them today.

### The audit could not have caught this

`check_listed_tool_freshness` reads `pushed_at` only. Vanna archiving right after a release surfaced as **200 days quiet — the mildest number in that week's table** — while archival is the strongest removal signal the policy recognises. Archived repos now get their own section ahead of the push-age table and are never folded into it, so one repo gets one verdict.

**Plus a silent write failure in the same function.** It appended to `.github/PROPOSED_UPDATES.md` without creating the directory, unlike both sibling audits which call `mkdir(parents=True, exist_ok=True)`. CI checkouts always have `.github/`, so it never bit in production, but the report was discardable by accident — and it blocked the new test until fixed.

**Tests** — 3 new, 90 passing: archived repo reported despite a fresh push date; archived repo not *also* listed as stale; active repo produces no archived section.

## Link

https://github.com/vanna-ai/vanna · https://github.com/Canner/WrenAI

## Category

README § Structured & SQL RAG, § Frameworks, § Data Ingestion, § Retrieval (GraphRAG), § Multimodal, § LLM-as-Judge, § Caching, § FinOps · `scripts/discovery_engine.py`

## ✅ Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months) — deliberately not, in every case; that is what this PR documents.
- [x] It solves a real-world production problem.
- [x] The link description follows the format: `[Name](URL) - Description.`
- [x] For new or substantially edited entries, I added/updated the `verified: 2026-08-21` marker (CONTRIBUTING.md § Last Verified Date).

## Engineering Context

- **Source URL:** GitHub API `repos/{slug}` and `repos/{slug}/releases` for all eleven, plus https://vanna.ai/ and https://pypi.org/pypi/vanna/json
- **Date (YYYY-MM-DD):** 2026-08-21
- **Tag:** N/A — no numeric performance, cost, or quality claim is introduced.
- **Methodology / harness link:** `tests/test_discovery_engine.py`
- **Notes:** Push dates and release history were pulled per repo rather than taken from the 2026-08-17 feed snapshot, since four days had passed. Vanna's site and PyPI package are both still live at 2.0.2, which is why the entry is soft-deprecated rather than removed: the code works, it just will not be fixed.
