### PR TITLE
Add mdgate/converters to Data Ingestion & Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ Choose the right framework for your use case with this production-focused compar
   - Specialized parsing for complex PDFs with table extraction capabilities.
 - [Marker](https://github.com/datalab-to/marker)
   - High-efficiency PDF, EPUB to Markdown converter using vision models.
+- [mdgate/converters](https://github.com/mdgate/converters)
+  <!-- verified: 2026-08-24 -->
+  - Pure TypeScript document-to-Markdown converters for RAG ingestion. Parses DOCX, PDF, PPTX, XLSX, iWork, HWP, email, and other office formats in Node, Cloudflare Workers, and browsers, with no Python, WASM, or native addons.
 - [OmniParse](https://github.com/adithya-s-k/omniparse)
   <!-- verified: 2026-08-21 -->
   - Universal parser for ingesting any data type (documents, multimedia, web)

--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ Choose the right framework for your use case with this production-focused compar
   - High-efficiency PDF, EPUB to Markdown converter using vision models.
 - [mdgate/converters](https://github.com/mdgate/converters)
   <!-- verified: 2026-08-24 -->
-  - Pure TypeScript document-to-Markdown converters for RAG ingestion. Parses DOCX, PDF, PPTX, XLSX, iWork, HWP, email, and other office formats in Node, Cloudflare Workers, and browsers, with no Python, WASM, or native addons.
+  - Pure TypeScript document-to-Markdown converter for RAG ingestion, parsing
+    DOCX, PDF, PPTX, XLSX, iWork, HWP, email, and other office formats in Node,
+    Cloudflare Workers, and browsers without Python, WASM, or native addons.
 - [OmniParse](https://github.com/adithya-s-k/omniparse)
   <!-- verified: 2026-08-21 -->
   - Universal parser for ingesting any data type (documents, multimedia, web)


### PR DESCRIPTION
## Description

mdgate/converters is a MIT-licensed TypeScript library that converts office documents, PDFs, iWork, HWP, and email into GitHub-Flavored Markdown. It is useful for RAG ingestion in Node, Cloudflare Workers, and browsers because it does not need Python, WASM, or native addons.

## Link

https://github.com/mdgate/converters

## Category

Data Ingestion & Parsing

## Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the format in CONTRIBUTING.md.
- [x] For new or substantially edited entries, I added/updated the `verified: YYYY-MM-DD` marker (CONTRIBUTING.md section Last Verified Date).

## Engineering Context

No numeric benchmark claims. The entry describes runtime portability (Node, Cloudflare Workers, browsers) and the absence of Python/WASM/native addons.
