### PR TITLE
Add Mnemoverse to Memory / Frameworks & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,11 @@ distinct from the RAG knowledge base itself.
     facts from every conversation turn. Provides a unified API across
     graph-based, vector, and key-value backends; selected as the memory
     provider in the AWS Agent SDK.
+- [Mnemoverse](https://github.com/mnemoverse/mcp-memory-server)
+  - Hosted memory reachable over MCP from Claude Code, Cursor, VS Code and
+    ChatGPT with one key, so context written in one tool is readable in the
+    next. Recall ranking moves with outcomes rather than similarity alone: a
+    memory that helped is promoted, one that misled is demoted.
 - [Vestige](https://github.com/samvallad33/vestige)
   <!-- verified: 2026-06-26 -->
   - Local-first memory MCP server for coding agents, written in Rust with a


### PR DESCRIPTION
Adds one entry to **Memory → Frameworks & Tools**, right after Mem0, in the existing two-line format.

**[Mnemoverse](https://github.com/mnemoverse/mcp-memory-server)** — hosted memory reachable over MCP from Claude Code, Cursor, VS Code and ChatGPT with a single key, so context written in one tool is readable in the next.

Why it is not another vector store behind a tool call, which is the distinction this section already draws between LangMem, Letta and Mem0:

- **Recall ranking moves with outcomes**, not similarity alone. A memory that helped is promoted, one that misled is demoted; the update is prediction-error driven rather than a decay curve on age.
- **Consolidation compresses without flattening**: near-duplicates merge into prototypes while distinctive outliers are protected.

MIT for the MCP server and the Python SDK, hosted engine. Listed in the official MCP registry as `io.github.mnemoverse/mcp-memory-server`.

Disclosure: I work on Mnemoverse. Happy to shorten the entry or move it if another subsection fits better.