### PR TITLE
ci(pages): never let a pull_request run reach the deploy job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,13 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main'
+    # PRs build the site but never publish it. Guarding on `github.ref` alone was
+    # not enough: a run that leaves the queue after its PR has merged no longer
+    # resolves `refs/pull/N/merge` and the job fails instead of skipping, which
+    # is how a red `deploy` check landed on an already-merged PR during the
+    # 2026-08-26 Actions incident. `workflow_dispatch` stays able to deploy so a
+    # missed push run can still be replayed by hand.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Follow-up to the Actions incident earlier today.

`deploy` was guarded on `github.ref == 'refs/heads/main'` alone. That skips normally, but a run that sits in the queue until after its PR merges can no longer resolve `refs/pull/N/merge`, and the job fails at startup rather than skipping — which is how #97 ended up with a red `deploy` check after it was already merged and its branch deleted.

Gating on the event as well makes the skip unconditional for PRs. `workflow_dispatch` deliberately still deploys, since that is what I used to replay the push runs the incident dropped.

PRs keep building the site, so a broken mkdocs build is still caught before merge.