### PR TITLE
Add TopK to Vector Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ training from scratch. See also: [rag-pitfalls.md — Embedding Model Selection]
 | [pgvector](https://github.com/pgvector/pgvector) | PostgreSQL Ecosystem | Vector search capability directly within PostgreSQL. | — |
 | [Pinecone](https://www.pinecone.io/) | 10M-100M+ vectors | Zero-ops, serverless architecture. | — |
 | [Qdrant](https://github.com/qdrant/qdrant) | <50M vectors | Best filtering support and free tier. | [\[V\]](benchmarks.md#1-vector-databases) [\[3P\]](benchmarks.md#1-vector-databases) |
+| [TopK](https://github.com/topk-io/topk) | Accuracy-critical hybrid retrieval | Late-interaction (MaxSim) multi-vector retrieval, BM25, and user-defined ranking expressions in one query, with embedding and reranking models managed alongside the index. | — |
 | [Vespa](https://github.com/vespa-engine/vespa) | Web-scale hybrid serving | Battle-tested engine combining vector, tensor, text, and structured data at serving time and any scale. | — |
 | [Weaviate](https://github.com/weaviate/weaviate) | Hybrid Search | Native integration of vector and keyword search. | — |
 


### PR DESCRIPTION
# Pull Request

## Description

Adds **TopK** to the Vector Databases table. TopK is a search engine aimed at
retrieval quality rather than vector storage alone: it combines dense vector
search, BM25, and late-interaction (MaxSim) multi-vector retrieval behind one
query, with embedding and reranking models managed alongside the index.

The production angle for this list is that multi-vector fields are indexed for
retrieval rather than rescoring. A document that a single-vector or keyword
first stage never returns can still surface, which removes a recall ceiling
that two-stage rerank pipelines otherwise carry into production.

It also removes a moving part from a deployed RAG stack, since embedding at
ingest and at query time happens inside the engine rather than in a separate
inference service that has to be versioned and kept in sync with the index.

## Link

https://github.com/topk-io/topk (Rust, MIT). Docs: https://docs.topk.io

## Category

Vector Databases. Placed alphabetically between Qdrant and Vespa.

## ✅ Checklist

- [x] I have checked that this resource is not already in the list.
- [x] This resource is actively maintained (updated in the last 6 months).
- [x] It solves a real-world production problem.
- [x] The link description follows the format: `[Name](URL) - Description.`
- [x] For new or substantially edited entries, I added/updated the `verified: YYYY-MM-DD` marker (CONTRIBUTING.md § Last Verified Date).

Two notes on the last two boxes, since this section is a table rather than a
bullet list. The entry follows the four-column table row format used by the
other rows in Vector Databases, not the two-line bullet format from
CONTRIBUTING § 3. No `verified:` marker is included because the marker is
defined for bullet entries, and `ENTRY_ANCHOR_RE` in `scripts/entry_patterns.py`
does not match table rows. I ran the six blocking content checks locally
against this change and all pass: format, alphabetical, duplicates,
verified-markers, style-bans, evidence-tags. Happy to switch to whichever form
you prefer if the table is meant to carry markers too.

## Engineering Context

Not applicable. This addition introduces no numeric claim (no latency, recall,
cost, or throughput figures), so per CONTRIBUTING § 4 no evidence tag is
required and the Evidence column is `—`, matching the majority of rows in the
table. If you would like the row to carry evidence, TopK publishes an open
benchmark harness at https://github.com/topk-io/bench that could be cited as
`[V]` under the vendor-stated tier.

- **Source URL:** n/a — no numeric claim
- **Date (YYYY-MM-DD):** n/a
- **Tag:** n/a
- **Methodology / harness link:** https://github.com/topk-io/bench (offered, not cited in the entry)
- **Notes:** Evidence column intentionally left as `—`.
